### PR TITLE
Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.log
+*.tgz
+
+/node_modules/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+*.log
+*.tgz
+
+.gitignore
+.npmignore
+
+/node_modules/
+/test/
+Gruntfile.js
+

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,15 +1,16 @@
 module.exports = function(grunt) {
+  "use strict";
+
+  var files = ['Gruntfile.js', 'tasks/**/*.js'];
+  //var files = ['Gruntfile.js', 'tasks/**/*.js', 'test/**/*.js'];
 
   // Project configuration.
   grunt.initConfig({
-    test: {
-      files: ['test/**/*.js']
-    },
-    lint: {
-      files: ['grunt.js', 'tasks/**/*.js', 'test/**/*.js']
-    },
+    //test: {
+    //  files: ['test/**/*.js']
+    //},
     watch: {
-      files: '<config:lint.files>',
+      files: files,
       tasks: 'default'
     },
     jshint: {
@@ -27,14 +28,17 @@ module.exports = function(grunt) {
         node: true,
         es5: true
       },
-      globals: {}
+      all: files
     }
   });
+
+  grunt.loadNpmTasks("grunt-contrib-jshint");
+  grunt.loadNpmTasks("grunt-contrib-watch");
 
   // Load local tasks.
   grunt.loadTasks('tasks');
 
   // Default task.
-  grunt.registerTask('default', 'lint test');
+  grunt.registerTask('default', 'jshint');
 
 };

--- a/package.json
+++ b/package.json
@@ -25,11 +25,10 @@
   "scripts": {
     "test": "grunt test"
   },
-  "dependencies": {
-    "grunt": "~0.4.0"
-  },
   "devDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": "~0.4.0",
+    "grunt-contrib-jshint": "~0.1.1",
+    "grunt-contrib-watch": "~0.2.0"
   },
   "keywords": ["gruntplugin"]
 }

--- a/tasks/grunt-cp.js
+++ b/tasks/grunt-cp.js
@@ -15,6 +15,7 @@
 // }
 
 module.exports = function(grunt) {
+  "use strict";
 
   var wrap;
 
@@ -29,7 +30,9 @@ module.exports = function(grunt) {
     // Concat specified files.
 
     this.files.forEach(function(file) {
-      if (!file.src) return;
+      if (!file.src) {
+        return;
+      }
       
       file.src.map(function(filepath) {
         src = wrap(filepath, { wrapper: this.data.wrapper });
@@ -38,7 +41,9 @@ module.exports = function(grunt) {
     }, this);
 
     // Fail task if errors were logged.
-    if (this.errorCount) return false;
+    if (this.errorCount) {
+      return false;
+    }
 
     // Otherwise, print a success message.
     grunt.log.writeln('Wrapped files created in "' + this.data.dest + '".');
@@ -53,6 +58,6 @@ module.exports = function(grunt) {
       wrapper: ['', '']
     });
     return options.wrapper[0] + grunt.file.read(filepath) + options.wrapper[1];
-  }
+  };
 
 };


### PR DESCRIPTION
### Changes
- Renaming grunt.js to Gruntfile.js (grunt@0.4)
- Total overhaul of Gruntfile.js to actually work with grunt-0.4
  - Added missing tasks to package.json
  - Renamed and clean up config
  - Excluded non-functioning tests
  - Made all files pass linting
- Adding .gitignore with some basic exclusions
- Cleaning up npm package/tar:
  - Excluded Gruntfile.js
  - Excluded test/ dir
  - Removed grunt as a regular dependency

`npm pack` cleanup result:
### Before

package/package.json
package/README.md
package/grunt.js
package/bin/grunt-wrap
package/LICENSE-MIT
package/tasks/grunt-cp.js
package/test/gruntplugin-example_test.js
### After

package/package.json
package/README.md
package/bin/grunt-wrap
package/LICENSE-MIT
package/tasks/grunt-cp.js
