### PR TITLE
Added wrapper-as-function

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ grunt.initConfig({
       src: ['assets/*.js'],
       dest: 'dist/',
       wrapper: ['define(function (require, exports, module) {\n', '\n});']
+      // wrapper can also be a function, like so:
+      //
+      // wrapper: function(filepath, options) {
+      //   // ...
+      //   return ['define(function (require, exports, module) {\n', '\n});'];
+      // }
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "author": {
     "name": "Christopher Rogers"
   },
+  "contributors": [
+    "cha0s <nodejs@therealcha0s.net> (https://github.com/cha0s)"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/chrissrogers/grunt-wrap.git"

--- a/tasks/grunt-cp.js
+++ b/tasks/grunt-cp.js
@@ -11,6 +11,11 @@
 //     src: ['assets/*.js'],
 //     dest: 'dist/',
 //     wrapper: ['define(function (require, exports, module) {\n', '\n});']
+//     // Or... 
+//     wrapper: function(filepath, options) {
+//       // ...
+//       return ['define(function (require, exports, module) {\n', '\n});'];
+//     }
 //   }
 // }
 
@@ -57,7 +62,11 @@ module.exports = function(grunt) {
     options = grunt.util._.defaults(options || {}, {
       wrapper: ['', '']
     });
-    return options.wrapper[0] + grunt.file.read(filepath) + options.wrapper[1];
+    var wrapper = options.wrapper;
+    if ('function' === typeof wrapper) {
+      wrapper = wrapper(filepath, options);
+    }
+    return wrapper[0] + grunt.file.read(filepath) + wrapper[1];
   };
 
 };


### PR DESCRIPTION
Wrapper may be a function invoked for every file taking filepath and options as args, and returning a 2-element array (as currently).

I wanted to generate a prefix/suffix derived from the filepath, and this lets anyone do arbitrarily complicated things like this, as well as leaving the default functionality for global prefix/suffix (as before).
