### PR TITLE
Default dest option to an empty string

### DIFF
--- a/tasks/grunt-cp.js
+++ b/tasks/grunt-cp.js
@@ -41,7 +41,7 @@ module.exports = function(grunt) {
       
       file.src.map(function(filepath) {
         src = wrap(filepath, { wrapper: this.data.wrapper });
-        grunt.file.write(path.join(this.data.dest, filepath), src);
+        grunt.file.write(path.join(this.data.dest || '', filepath), src);
       }, this);
     }, this);
 


### PR DESCRIPTION
Use an empty string for dest when not defined to prevent path.join warnings in node 0.10.

Warning: Arguments to path.join must be strings
