### PR TITLE
Use verbose for each file wrapping log

### DIFF
--- a/tasks/wrap.js
+++ b/tasks/wrap.js
@@ -43,9 +43,8 @@ module.exports = function (grunt) {
         if (grunt.file.isDir(src)) {
           grunt.file.mkdir(dest);
         } else {
-          grunt.log.write('Wrapping ' + src.cyan + ' -> ' + dest.cyan + '...');
+          grunt.verbose.writeln(['Wrapping ' + src.cyan + ' -> ' + dest.cyan + '...']);
           grunt.file.write(dest, wrap(src, options));
-          grunt.log.ok();
           counter++;
         }
       });


### PR DESCRIPTION
Logs is overwhelming when you have to wrap hundreds of files. 
Final log which indicates how many files were wrapped is sufficient for most cases :)

Using grunt `--verbose` flag when you have a problem or want to check what happen.

By the way I've removed the `grunt.log.ok()` call right after `grunt.file.write()` as this function return two (verbose) log messages + `grunt.verbose.ok()`, one for the read operation and another for the write one.
